### PR TITLE
Fix for IOTCLT-961

### DIFF
--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -162,12 +162,16 @@ bool M2MConnectionHandlerPimpl::resolve_server_address(const String& server_addr
 void M2MConnectionHandlerPimpl::dns_handler()
 {
     tr_debug("M2MConnectionHandlerPimpl::dns_handler()");
+    if(_socket_address) {
+        delete _socket_address;
+       _socket_address = NULL;
+    }
     _socket_address = new SocketAddress(_net_iface,_server_address.c_str(), _server_port);
     if(*_socket_address) {
-        _address._address = (void*)_socket_address->get_ip_address();
+        _address._length = strlen(_socket_address->get_ip_address());
+        memcpy(_address._address,_socket_address->get_ip_address(),_address._length);
         tr_debug("IP Address %s",_socket_address->get_ip_address());
-        tr_debug("Port %d",_socket_address->get_port());
-        _address._length = strlen((char*)_address._address);
+        tr_debug("Port %d",_socket_address->get_port());        
         _address._port = _socket_address->get_port();
         _address._stack = _network_stack;
     } else {

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -116,6 +116,10 @@ M2MConnectionHandlerPimpl::M2MConnectionHandlerPimpl(M2MConnectionHandler* base,
 M2MConnectionHandlerPimpl::~M2MConnectionHandlerPimpl()
 {
     tr_debug("M2MConnectionHandlerPimpl::~M2MConnectionHandlerPimpl()");
+    if(_socket_address) {
+        delete _socket_address;
+        _socket_address = NULL;
+    }
     if (_socket) {
         delete _socket;
         _socket = 0;
@@ -168,10 +172,10 @@ void M2MConnectionHandlerPimpl::dns_handler()
     }
     _socket_address = new SocketAddress(_net_iface,_server_address.c_str(), _server_port);
     if(*_socket_address) {
-        _address._length = strlen(_socket_address->get_ip_address());
-        memcpy(_address._address,_socket_address->get_ip_address(),_address._length);
+        _address._address = (void*)_socket_address->get_ip_address();
         tr_debug("IP Address %s",_socket_address->get_ip_address());
-        tr_debug("Port %d",_socket_address->get_port());        
+        tr_debug("Port %d",_socket_address->get_port());
+        _address._length = strlen((char*)_address._address);
         _address._port = _socket_address->get_port();
         _address._stack = _network_stack;
     } else {


### PR DESCRIPTION
This commit fixes issue of mapping of IP addresses for CoAP library is done.
The problem was hidden till now, because IP addresses of Bootstrap and mDS were quite different and client was accidently only comparing first 4 characters of the address hence it was identifying them as two different servers.
But now the IP addresses are similar to last 2 bytes hence the first 4 byte check always pass even though the IP addresses are different
IP Address of Bootstrap is 159.122.226.36
IP Address of mDS is 159.122.226.33
On comparing the first 4 characters now, the CoAP library assumes the requests are still coming for Bootstrap sequence.
This commit fixes this issue.