### PR TITLE
Fix irq contexts

### DIFF
--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -317,8 +317,6 @@ int8_t M2MConnectionHandlerPimpl::connection_tasklet_handler()
 
 void M2MConnectionHandlerPimpl::socket_event()
 {
-    tr_debug("M2MConnectionHandlerPimpl::socket_event()");
-
     TaskIdentifier* task = (TaskIdentifier*)malloc(sizeof(TaskIdentifier));
     if (!task) {
     	_observer.socket_error(M2MConnectionHandler::SOCKET_READ_ERROR, true);

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -27,10 +27,19 @@
 #include "eventOS_scheduler.h"
 
 #include "mbed-trace/mbed_trace.h"
+#include "mbed.h"
 
 #define TRACE_GROUP "mClt"
 
+#ifdef MBED_CONF_MBED_CLIENT_EVENT_LOOP_SIZE
+#define MBED_CLIENT_EVENT_LOOP_SIZE MBED_CONF_MBED_CLIENT_EVENT_LOOP_SIZE
+#else
+#define MBED_CLIENT_EVENT_LOOP_SIZE 1024
+#endif
+
 int8_t M2MConnectionHandlerPimpl::_tasklet_id = -1;
+
+static MemoryPool<M2MConnectionHandlerPimpl::TaskIdentifier, MBED_CLIENT_EVENT_LOOP_SIZE/64> memory_pool;
 
 extern "C" void connection_tasklet_event_handler(arm_event_s *event)
 {
@@ -73,7 +82,7 @@ extern "C" void connection_tasklet_event_handler(arm_event_s *event)
             break;
     }
     if (task_id) {
-        free(task_id);
+        memory_pool.free(task_id);
     }
 }
 
@@ -148,7 +157,7 @@ bool M2MConnectionHandlerPimpl::resolve_server_address(const String& server_addr
     _server_port = server_port;
     _server_type = server_type;
     _server_address = server_address;
-    TaskIdentifier* task = (TaskIdentifier*)malloc(sizeof(TaskIdentifier));
+    TaskIdentifier* task = memory_pool.alloc();
     if (!task) {
         return false;
     }
@@ -255,7 +264,7 @@ bool M2MConnectionHandlerPimpl::send_data(uint8_t *data,
         return false;
     }
 
-    TaskIdentifier* task = (TaskIdentifier*)malloc(sizeof(TaskIdentifier));
+    TaskIdentifier* task = memory_pool.alloc();
     if (!task) {
         free(buffer);
         return false;
@@ -317,7 +326,7 @@ int8_t M2MConnectionHandlerPimpl::connection_tasklet_handler()
 
 void M2MConnectionHandlerPimpl::socket_event()
 {
-    TaskIdentifier* task = (TaskIdentifier*)malloc(sizeof(TaskIdentifier));
+    TaskIdentifier* task = memory_pool.alloc();
     if (!task) {
     	_observer.socket_error(M2MConnectionHandler::SOCKET_READ_ERROR, true);
         return;


### PR DESCRIPTION
Should resolve https://github.com/ARMmbed/mbed-os-example-client/issues/75

mbed-client defines `M2MConnectionHandlerPimpl::socket_event` for handling the event passed through the `UDPSocket::attach` function. Unfortunately, the previous implementation contained both a `tr_debug` call and `malloc` call that were unacceptably long-running and caused UART bytes to be dropped.

This issue was not unnoticable in lwip's implementation. We could update lwip to dispatch events in a critical section, insuring correct behaviour, although this would introduce unnecessary jitter in existing code.

moved from https://github.com/ARMmbed/mbed-os/pull/2530
cc @yogpan01, @jupe 