### PR TITLE
Remove explicit request from receiveFrom address

### DIFF
--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -411,9 +411,7 @@ int M2MConnectionHandlerPimpl::receive_from_socket(unsigned char *buf, size_t le
         status = pal_recv(_socket, buf, len, &recv_len);
 #endif //PAL_NET_TCP_AND_TLS_SUPPORT
     } else {
-        palSocketAddress_t from;
-        palSocketLength_t length;
-        status = pal_receiveFrom(_socket, buf, len, &from, &length, &recv_len);
+        status = pal_receiveFrom(_socket, buf, len, NULL, NULL, &recv_len);
     }
 
     if(status == PAL_SUCCESS){


### PR DESCRIPTION
Some devices currently have the limitation of not returning a valid address from a UDP receive. The PAL enforces a valid address if requested, causing the receive to fail.

Since client does not use the resulting address from receiveFrom, requesting an address is unnecessary. Removing the request allows client to support more, less-functional devices.

related issue: ARMmbed/mbed-os#3314