### PR TITLE
connectionhandler: remove unnecessary include dependency on mbedos

### DIFF
--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -29,7 +29,8 @@
 #include "eventOS_event.h"
 
 #include "mbed-trace/mbed_trace.h"
-#include "mbed.h"
+
+#include <stdlib.h> // free() and malloc()
 
 #define TRACE_GROUP "mClt"
 


### PR DESCRIPTION
The code used mbed.h to get declaration of malloc() and free().
Replace that with platfom independent stdlib.h.