### PR TITLE
connectionhandler: tcp: unconditionally perform pal_close() on (re)init

### DIFF
--- a/mbed-client-classic/m2mconnectionhandlerpimpl.h
+++ b/mbed-client-classic/m2mconnectionhandlerpimpl.h
@@ -64,7 +64,7 @@ public:
     * @brief Destructor
     */
     ~M2MConnectionHandlerPimpl();
-    
+
     void start_timer(void);
 
     /**
@@ -187,7 +187,7 @@ public:
     * @brief Sends data to socket through event loop.
     */
     void send_socket_data(uint8_t *data, uint16_t data_len);
-    
+
     void send_receive_event(void);
 
 
@@ -232,6 +232,9 @@ private:
         /** pal_connect() is in progress. */
         ESocketStateConnectBeingCalled,
 
+        /** pal_close() is in progress. */
+        ESocketStateCloseBeingCalled,
+
         /** pal_connect() has been called and we are waiting for asynchronous response. */
         ESocketStateConnecting,
 
@@ -249,7 +252,7 @@ private:
     M2MConnectionObserver::SocketAddress        _address;
 
     // _address._address will point to one of these two
-    palIpV4Addr_t                               _ipV4Addr; 
+    palIpV4Addr_t                               _ipV4Addr;
     palIpV6Addr_t                               _ipV6Addr;
 
     palSocket_t                                 _socket;

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -206,6 +206,11 @@ void M2MConnectionHandlerPimpl::dns_handler()
     tr_debug("M2MConnectionHandlerPimpl::dns_handler - _socket_state = %d", _socket_state);
 
     switch (_socket_state) {
+        case ESocketStateConnectBeingCalled:
+        case ESocketStateCloseBeingCalled:
+            // Ignore these events
+            break;
+
         case ESocketStateDisconnected:
 
             // Initialize the socket to stable state
@@ -368,6 +373,7 @@ void M2MConnectionHandlerPimpl::dns_handler()
                 } else {
                     tr_debug("dns_handler() - connect+select not ready yet, continue waiting");
                 }
+
             }
             break;
     }

--- a/test/mbed-client-classic/unittest/makefile_defines.txt
+++ b/test/mbed-client-classic/unittest/makefile_defines.txt
@@ -31,6 +31,7 @@ INCLUDE_DIRS =\
   ../../../../test_modules/mbed-os/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos\
   ../../../../test_modules/mbed-os/hal/storage_abstraction\
   ../../../../test_modules/mbed-coap/\
+  ../../../../test_modules/mbed-coap/mbed-coap/\
   /usr/include\
   $(CPPUTEST_HOME)/include\
 


### PR DESCRIPTION
The close_socket() was not calling pal_close() if the _running
was not on. This may be the reason for random failures on reconnect.
To be tested.

While here, move the socket_close() to be done before the error callbacks,
so the callback might be able to re-initialize the connection sequence.