### PR TITLE
connectionhandlerpimpl: add more detailed traces on error cases

### DIFF
--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -219,8 +219,7 @@ void M2MConnectionHandlerPimpl::dns_handler()
             status = pal_getAddressInfo(_server_address.c_str(), &_socket_address, &_socket_address_len);
             if (PAL_SUCCESS != status) {
                 tr_error("addrInfo, err: %d", (int)status);
-                // XXX: the error code given to client is wrong, a DNS_RESOLVING_ERROR might be better here.
-                _observer.socket_error(M2MConnectionHandler::SOCKET_ABORT);
+                _observer.socket_error(M2MConnectionHandler::DNS_RESOLVING_ERROR);
                 return;
             }
             status = pal_setSockAddrPort(&_socket_address, _server_port);
@@ -236,11 +235,11 @@ void M2MConnectionHandlerPimpl::dns_handler()
                 status = pal_getSockAddrIPV4Addr(&_socket_address,_ipV4Addr);
                 if (PAL_SUCCESS != status) {
                     tr_error("sockAddr4, err: %d", (int)status);
-                    _observer.socket_error(M2MConnectionHandler::SOCKET_ABORT);
+                    _observer.socket_error(M2MConnectionHandler::DNS_RESOLVING_ERROR);
                     return;
                 }
 
-                tr_debug("IP Address %s",tr_array(_ipV4Addr, 4));
+                tr_debug("IPv4 Address %s", tr_array(_ipV4Addr, 4));
 
                 _address._address = (void*)_ipV4Addr;
                 _address._length = PAL_IPV4_ADDRESS_SIZE;
@@ -251,11 +250,11 @@ void M2MConnectionHandlerPimpl::dns_handler()
                 status = pal_getSockAddrIPV6Addr(&_socket_address,_ipV6Addr);
                 if (PAL_SUCCESS != status) {
                     tr_error("sockAddr6, err: %d", (int)status);
-                    _observer.socket_error(M2MConnectionHandler::SOCKET_ABORT);
+                    _observer.socket_error(M2MConnectionHandler::DNS_RESOLVING_ERROR);
                     return;
                 }
 
-                tr_debug("IP Address %s",tr_array(_ipV6Addr,sizeof(_ipV6Addr)));
+                tr_debug("IPv6 Address %s", tr_array(_ipV6Addr,sizeof(_ipV6Addr)));
 
                 _address._address = (void*)_ipV6Addr;
                 _address._length = PAL_IPV6_ADDRESS_SIZE;

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -223,7 +223,14 @@ void M2MConnectionHandlerPimpl::dns_handler()
                 _observer.socket_error(M2MConnectionHandler::SOCKET_ABORT);
                 return;
             }
-            pal_setSockAddrPort(&_socket_address, _server_port);
+            status = pal_setSockAddrPort(&_socket_address, _server_port);
+
+            if (PAL_SUCCESS != status) {
+                tr_error("setSockAddrPort err: %d", (int)status);
+            } else {
+                tr_debug("address family: %d", (int)_socket_address.addressType);
+                tr_debug("addr : %s", tr_array((const uint8_t*)_socket_address.addressData, 32));
+            }
 
             if(_network_stack == M2MInterface::LwIP_IPv4 ||
                _network_stack == M2MInterface::ATWINC_IPv4){
@@ -723,6 +730,8 @@ bool M2MConnectionHandlerPimpl::init_socket()
         pal_setSockAddrIPV4Addr(&bind_address, interface_address4);
     } else if(_network_stack == M2MInterface::LwIP_IPv6){
         pal_setSockAddrIPV6Addr(&bind_address, interface_address6);
+    } else {
+        tr_warn("stack type: %d", _network_stack);
     }
 
     pal_setSockAddrPort(&bind_address, _listen_port);

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -232,8 +232,7 @@ void M2MConnectionHandlerPimpl::dns_handler()
                 tr_debug("addr : %s", tr_array((const uint8_t*)_socket_address.addressData, 32));
             }
 
-            if(_network_stack == M2MInterface::LwIP_IPv4 ||
-               _network_stack == M2MInterface::ATWINC_IPv4){
+            if (_socket_address.addressType == PAL_AF_INET) {
                 status = pal_getSockAddrIPV4Addr(&_socket_address,_ipV4Addr);
                 if (PAL_SUCCESS != status) {
                     tr_error("sockAddr4, err: %d", (int)status);
@@ -248,8 +247,7 @@ void M2MConnectionHandlerPimpl::dns_handler()
                 _address._port = _server_port;
                 _address._stack = _network_stack;
             }
-            else if(_network_stack == M2MInterface::LwIP_IPv6 ||
-                    _network_stack == M2MInterface::Nanostack_IPv6){
+            else if (_socket_address.addressType == PAL_AF_INET6) {
                 status = pal_getSockAddrIPV6Addr(&_socket_address,_ipV6Addr);
                 if (PAL_SUCCESS != status) {
                     tr_error("sockAddr6, err: %d", (int)status);


### PR DESCRIPTION
Add more tracing on the error paths to make it easier to find
reason for the networking issues.

While here, remove double calls to observer error callback
which happened if the init_socket() failed.