### PR TITLE
Only include pal.h instead of sub-components.

### DIFF
--- a/mbed-client-classic/m2mconnectionhandlerpimpl.h
+++ b/mbed-client-classic/m2mconnectionhandlerpimpl.h
@@ -23,9 +23,7 @@
 #include "mbed-client/m2mconnectionobserver.h"
 #include "mbed-client/m2mconnectionsecurity.h"
 #include "nsdl-c/sn_nsdl.h"
-
-#include "pal_network.h"
-
+#include "pal.h"
 
 class M2MConnectionSecurity;
 class M2MConnectionHandler;

--- a/mbed-client-classic/m2mconnectionhandlerpimpl.h
+++ b/mbed-client-classic/m2mconnectionhandlerpimpl.h
@@ -24,6 +24,7 @@
 #include "mbed-client/m2mconnectionsecurity.h"
 #include "nsdl-c/sn_nsdl.h"
 #include "pal.h"
+#include "pal_network.h"
 
 class M2MConnectionSecurity;
 class M2MConnectionHandler;

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -25,10 +25,6 @@
 #include "mbed-client/m2mconnectionhandler.h"
 
 #include "pal.h"
-#include "pal_rtos.h"
-#include "pal_errors.h"
-#include "pal_macros.h"
-#include "pal_network.h"
 
 #include "eventOS_scheduler.h"
 #include "eventOS_event.h"

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -25,6 +25,7 @@
 #include "mbed-client/m2mconnectionhandler.h"
 
 #include "pal.h"
+#include "pal_network.h"
 
 #include "eventOS_scheduler.h"
 #include "eventOS_event.h"

--- a/test/mbed-client-classic/unittest/stub/pal_network_stub.h
+++ b/test/mbed-client-classic/unittest/stub/pal_network_stub.h
@@ -17,7 +17,7 @@
 #ifndef PAL_NETWORK_STUB_H
 #define PAL_NETWORK_STUB_H
 
-#include "pal_network.h"
+#include "pal.h"
 
 namespace pal_network_stub
 {
@@ -36,3 +36,4 @@ namespace pal_network_stub
 }
 
 #endif // PAL_NETWORK_STUB_H
+

--- a/test/mbed-client-classic/unittest/stub/pal_network_stub.h
+++ b/test/mbed-client-classic/unittest/stub/pal_network_stub.h
@@ -18,6 +18,7 @@
 #define PAL_NETWORK_STUB_H
 
 #include "pal.h"
+#include "pal_network.h"
 
 namespace pal_network_stub
 {


### PR DESCRIPTION
Simplifying include structure and only use pal.h