### PR TITLE
Fix socket_init() for Dual stack/IPv6

### DIFF
--- a/mbed-client-classic/m2mconnectionhandlerpimpl.h
+++ b/mbed-client-classic/m2mconnectionhandlerpimpl.h
@@ -57,7 +57,7 @@ public:
     M2MConnectionHandlerPimpl(M2MConnectionHandler* base, M2MConnectionObserver &observer,
                               M2MConnectionSecurity* sec,
                               M2MInterface::BindingMode mode,
-                              M2MInterface::NetworkStack stack);
+                              M2MInterface::NetworkStack /*stack*/);
 
     /**
     * @brief Destructor
@@ -247,7 +247,6 @@ private:
     const M2MSecurity                           *_security; //non-owned
     bool                                        _use_secure_connection;
     M2MInterface::BindingMode                   _binding_mode;
-    M2MInterface::NetworkStack                  _network_stack;
     M2MConnectionObserver::SocketAddress        _address;
 
     // _address._address will point to one of these two


### PR DESCRIPTION
10:27:04 10:27:04.184 | D1 <-- DutThread: [1239][DBG ][mClt]: IPv6 Address 26:07:f0:d0:26:01:00:52:00:01:00:00:00:00:00:20
10:27:04 10:27:04.185 | D1 <-- DutThread: [1240][DBG ][mClt]: init_socket - IN
10:27:04 10:27:04.185 | D1 <-- DutThread: [1241][DBG ][mClt]: Interface count: 7
10:27:04 10:27:04.185 | D1 <-- DutThread: [1242][DBG ][mClt]: Interface name: 
10:27:04 10:27:04.185 | D1 <-- DutThread: [1243][DBG ][mClt]: Interface no: 6
10:27:04 10:27:04.185 | D1 <-- DutThread: [1244][DBG ][mClt]: init_socket - port 0
10:27:04 10:27:04.186 | D1 <-- DutThread: [1245][DBG ][mClt]: init_socket - OUT
10:27:04 10:27:04.186 | D1 <-- DutThread: [1246][DBG ][mClt]: resolve_server_address - Using TCP
10:27:04 10:27:04.187 | D1 <-- DutThread: [1247][DBG ][mClt]: pal_connect(): -65533, async connect started

Original implementation was trying to force IPv4.