### PR TITLE
Update socket callback signature to match new API

### DIFF
--- a/mbed-client-classic/m2mconnectionhandlerpimpl.h
+++ b/mbed-client-classic/m2mconnectionhandlerpimpl.h
@@ -24,7 +24,6 @@
 #include "mbed-client/m2mconnectionsecurity.h"
 #include "nsdl-c/sn_nsdl.h"
 #include "pal.h"
-#include "pal_network.h"
 
 class M2MConnectionSecurity;
 class M2MConnectionHandler;

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -105,8 +105,9 @@ void M2MConnectionHandlerPimpl::send_receive_event(void)
     }
 }
 
-extern "C" void socket_event_handler(void)
+extern "C" void socket_event_handler(void* arg)
 {
+    (void*)arg;
     if(!connection_handler) {
         return;
     }

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -25,9 +25,6 @@
 #include "mbed-client/m2mconnectionhandler.h"
 
 #include "pal.h"
-#include "pal_errors.h"
-#include "pal_macros.h"
-#include "pal_network.h"
 
 #include "eventOS_scheduler.h"
 #include "eventOS_event.h"


### PR DESCRIPTION
PAL API for socket callback has changed to include a context argument, update callback function to match that