### PR TITLE
m2mconnectionhandlerpimpl: retry TCP connect instead of using select

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,27 @@ Client team's working area and we publish the official, tested versions as part 
 
 If you want to see an example application - a better starting point would be the [mbed OS example client](https://github.com/ARMmbed/mbed-os-example-client).
 
+## Running unit tests
+1. Use the following command to clone required git repositories:
 
+        make -f Makefile.test clone
 
+2. After the cloning is done run the unit tests with:
+
+        make -f Makefile.test test
+    
+### Pre-requisites for the unit tests
+install the following tools:
+- CppUTest
+- XSL
+- lcov
+- gcovr
+- Ninja 
+
+To install these tools on Ubuntu run the following commands:
+
+    sudo apt-get install cpputest
+    sudo apt-get install xsltproc
+    sudo apt-get install lcov
+    sudo apt-get install gcovr
+    sudo apt-get install ninja-build

--- a/mbed-client-classic/m2mconnectionhandlerpimpl.h
+++ b/mbed-client-classic/m2mconnectionhandlerpimpl.h
@@ -189,7 +189,6 @@ public:
 
     void send_receive_event(void);
 
-
 private:
 
     /**
@@ -270,6 +269,7 @@ private:
     // asynchronous events and callbacks. Note: the state may be accessed from
     // event sender and receiver threads.
     volatile SocketState                        _socket_state;
+    uint8_t                                     _handshake_retry;
 
 friend class Test_M2MConnectionHandlerPimpl;
 friend class Test_M2MConnectionHandlerPimpl_mbed;

--- a/mbed-client-classic/m2mconnectionhandlerpimpl.h
+++ b/mbed-client-classic/m2mconnectionhandlerpimpl.h
@@ -24,7 +24,6 @@
 #include "mbed-client/m2mconnectionsecurity.h"
 #include "nsdl-c/sn_nsdl.h"
 #include "pal.h"
-#include "pal_network.h"
 
 class M2MConnectionSecurity;
 class M2MConnectionHandler;

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -34,7 +34,8 @@
 #include "eventOS_event_timer.h"
 
 #include "mbed-trace/mbed_trace.h"
-#include "mbed.h"
+
+#include <stdlib.h> // free() and malloc()
 
 #define TRACE_GROUP "mClt"
 

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2015 - 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.
@@ -25,16 +25,22 @@
 #include "mbed-client/m2mconnectionhandler.h"
 
 #include "pal.h"
+#include "pal_errors.h"
+#include "pal_macros.h"
 #include "pal_network.h"
 
 #include "eventOS_scheduler.h"
 #include "eventOS_event.h"
+#include "eventOS_event_timer.h"
 
 #include "mbed-trace/mbed_trace.h"
-
-#include <stdlib.h> // free() and malloc()
+#include "mbed.h"
 
 #define TRACE_GROUP "mClt"
+
+#ifndef CONNECTION_TLS_MAX_RETRY
+#define CONNECTION_TLS_MAX_RETRY 60
+#endif
 
 int8_t M2MConnectionHandlerPimpl::_tasklet_id = -1;
 
@@ -93,7 +99,9 @@ void M2MConnectionHandlerPimpl::send_receive_event(void)
         event.event_type = ESocketDnsHandler;
     }
 
-    eventOS_event_send(&event);
+    if(eventOS_event_send(&event)){
+        _observer.socket_error(M2MConnectionHandler::SOCKET_READ_ERROR, true);
+    }
 }
 
 extern "C" void socket_event_handler(void)
@@ -122,7 +130,8 @@ M2MConnectionHandlerPimpl::M2MConnectionHandlerPimpl(M2MConnectionHandler* base,
  _listen_port(0),
  _running(false),
  _net_iface(0),
-_socket_state(ESocketStateDisconnected)
+ _socket_state(ESocketStateDisconnected),
+ _handshake_retry(0)
 {
 #ifndef PAL_NET_TCP_AND_TLS_SUPPORT
     if (is_tcp_connection()) {
@@ -315,6 +324,7 @@ void M2MConnectionHandlerPimpl::dns_handler()
         // fall through is a normal flow in case the UDP was used or pal_connect() happened to return immediately with PAL_SUCCESS
         case ESocketStateConnected:
             if (_security) {
+                _use_secure_connection = true;
                 if (_security->resource_value_int(M2MSecurity::SecurityMode) == M2MSecurity::Certificate ||
                     _security->resource_value_int(M2MSecurity::SecurityMode) == M2MSecurity::Psk) {
                     if( _security_impl != NULL ){
@@ -322,13 +332,7 @@ void M2MConnectionHandlerPimpl::dns_handler()
                         if (_security_impl->init(_security) == 0) {
                             _is_handshaking = true;
                             tr_debug("resolve_server_address - connect DTLS");
-                            if(_security_impl->start_connecting_non_blocking(_base) < 0 ){
-                                tr_debug("dns_handler - handshake failed");
-                                _is_handshaking = false;
-                                close_socket();
-                                _observer.socket_error(M2MConnectionHandler::SSL_CONNECTION_ERROR);
-                                return;
-                            }
+                            send_receive_event();
                         } else {
                             tr_error("resolve_server_address - init failed");
                             close_socket();
@@ -596,19 +600,15 @@ bool M2MConnectionHandlerPimpl::is_handshake_ongoing()
 
 void M2MConnectionHandlerPimpl::receive_handler()
 {
-    tr_debug("receive_handler()");
     if(_is_handshaking){
         receive_handshake_handler();
-        return;
     }
 
-    if(!_listening || !_running) {
-        return;
-    }
+    else if(_listening && _running){
 
-    if( _use_secure_connection ){
-        int rcv_size;
-        do{
+        if( _use_secure_connection ){
+
+            int rcv_size;
             rcv_size = _security_impl->read(_recv_buffer, sizeof(_recv_buffer));
             if(rcv_size > 0){
                 _observer.data_available((uint8_t*)_recv_buffer,
@@ -618,11 +618,11 @@ void M2MConnectionHandlerPimpl::receive_handler()
                 close_socket();
                 return;
             }
-        } while(M2MConnectionHandler::CONNECTION_ERROR_WANTS_READ != rcv_size);
-    } else{
-        size_t recv;
-        palStatus_t status;
-        do{
+
+        } else{
+            size_t recv;
+            palStatus_t status;
+
             if(is_tcp_connection()){
 #ifdef PAL_NET_TCP_AND_TLS_SUPPORT
                 status = pal_recv(_socket, _recv_buffer, sizeof(_recv_buffer), &recv);
@@ -661,8 +661,10 @@ void M2MConnectionHandlerPimpl::receive_handler()
                 }
 #endif //PAL_NET_TCP_AND_TLS_SUPPORT
             }
-        } while(status != PAL_ERR_SOCKET_WOULD_BLOCK);
+        }
+
     }
+
 }
 
 void M2MConnectionHandlerPimpl::claim_mutex()
@@ -726,6 +728,8 @@ bool M2MConnectionHandlerPimpl::init_socket()
 
     pal_setSockAddrPort(&bind_address, _listen_port);
     pal_bind(_socket, &bind_address, sizeof(bind_address));
+
+    _security_impl->set_socket(_socket, &_socket_address);
 
     tr_debug("init_socket - OUT");
     return true;

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -571,26 +571,49 @@ void M2MConnectionHandlerPimpl::set_platform_network_handler(void *handler)
 
 void M2MConnectionHandlerPimpl::receive_handshake_handler()
 {
+    int return_value;
     tr_debug("receive_handshake_handler()");
+
     if( _is_handshaking ){
-        int ret = _security_impl->continue_connecting();
-        tr_debug("ret %d", ret);
-        if( ret == M2MConnectionHandler::CONNECTION_ERROR_WANTS_READ ){ //We wait for next readable event
-            tr_debug("We wait for next readable event");
-            return;
-        } else if( ret == 0 ){
+
+        return_value = _security_impl->connect(_base);
+
+        if(!return_value){
+
+            _handshake_retry = 0;
             _is_handshaking = false;
             _use_secure_connection = true;
             enable_keepalive();
             _observer.address_ready(_address,
                                     _server_type,
                                     _server_port);
-        } else if( ret < 0 ){
+
+        }
+        else if(return_value != M2MConnectionHandler::CONNECTION_ERROR_WANTS_READ){
+
+            _handshake_retry = 0;
             _is_handshaking = false;
             _observer.socket_error(M2MConnectionHandler::SSL_CONNECTION_ERROR, true);
             close_socket();
+
         }
+        else{
+
+            if(_handshake_retry++ > CONNECTION_TLS_MAX_RETRY){
+
+                _handshake_retry = 0;
+                _is_handshaking = false;
+                _observer.socket_error(M2MConnectionHandler::SSL_CONNECTION_ERROR, true);
+                close_socket();
+
+            }
+            eventOS_event_timer_cancel(ESocketReadytoRead, M2MConnectionHandlerPimpl::_tasklet_id);
+            eventOS_event_timer_request(ESocketReadytoRead, ESocketReadytoRead, M2MConnectionHandlerPimpl::_tasklet_id, 1000);
+
+        }
+
     }
+
 }
 
 bool M2MConnectionHandlerPimpl::is_handshake_ongoing()

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -25,9 +25,6 @@
 #include "mbed-client/m2mconnectionhandler.h"
 
 #include "pal.h"
-#include "pal_errors.h"
-#include "pal_macros.h"
-#include "pal_network.h"
 
 #include "eventOS_scheduler.h"
 #include "eventOS_event.h"
@@ -105,8 +102,9 @@ void M2MConnectionHandlerPimpl::send_receive_event(void)
     }
 }
 
-extern "C" void socket_event_handler(void)
+extern "C" void socket_event_handler(void* arg)
 {
+    (void*)arg;
     if(!connection_handler) {
         return;
     }

--- a/source/m2mconnectionhandlerpimpl.cpp
+++ b/source/m2mconnectionhandlerpimpl.cpp
@@ -592,7 +592,7 @@ void M2MConnectionHandlerPimpl::receive_handshake_handler()
 
             _handshake_retry = 0;
             _is_handshaking = false;
-            _observer.socket_error(M2MConnectionHandler::SSL_CONNECTION_ERROR, true);
+            _observer.socket_error(M2MConnectionHandler::SSL_CONNECTION_ERROR, false);
             close_socket();
 
         }
@@ -602,7 +602,7 @@ void M2MConnectionHandlerPimpl::receive_handshake_handler()
 
                 _handshake_retry = 0;
                 _is_handshaking = false;
-                _observer.socket_error(M2MConnectionHandler::SSL_CONNECTION_ERROR, true);
+                _observer.socket_error(M2MConnectionHandler::SSL_CONNECTION_ERROR, false);
                 close_socket();
 
             }

--- a/test/mbed-client-classic/unittest/m2mconnectionhandlerpimpl_classic/Makefile
+++ b/test/mbed-client-classic/unittest/m2mconnectionhandlerpimpl_classic/Makefile
@@ -21,6 +21,9 @@ TEST_SRC_FILES = \
        ../stub/m2mstringbufferbase_stub.cpp \
        ../stub/nsdlaccesshelper_stub.cpp \
        ../stub/pal_stub.cpp \
+       ../stub/nsdlaccesshelper_stub.cpp \
+       ../stub/m2mstringbufferbase_stub.cpp \
+
 
 
 

--- a/test/mbed-client-classic/unittest/m2mconnectionhandlerpimpl_classic/test_m2mconnectionhandlerpimpl_classic.cpp
+++ b/test/mbed-client-classic/unittest/m2mconnectionhandlerpimpl_classic/test_m2mconnectionhandlerpimpl_classic.cpp
@@ -158,18 +158,6 @@ void Test_M2MConnectionHandlerPimpl_classic::test_dns_handler()
 
     /* error cases */
 
-    observer->addressReady = false;
-    observer->error = false;
-    m2msecurity_stub::int_value = M2MSecurity::Psk;
-    m2mconnectionsecurityimpl_stub::use_inc_int = false;
-    m2mconnectionsecurityimpl_stub::int_value = 0;
-    m2mconnectionsecurityimpl_stub::int_value2 = -123;
-    udp4_sec->resolve_server_address("1", 12345, M2MConnectionObserver::LWM2MServer, sec);
-    udp4_sec->dns_handler();
-    CHECK(observer->error);
-    CHECK(observer->addressReady == false);
-    CHECK(!udp4_sec->is_handshake_ongoing());
-
     M2MConnectionSecurity *connection_security;
 
     observer->error = false;
@@ -437,16 +425,6 @@ void Test_M2MConnectionHandlerPimpl_classic::test_receive_handler()
     CHECK(!observer->error);
 
     udp4_sec->_is_handshaking = false;
-    udp4_sec->_running = true;
-    observer->error = 0;
-    observer->dataAvailable = false;
-    m2mconnectionsecurityimpl_stub::use_inc_int = true;
-    m2mconnectionsecurityimpl_stub::inc_int_value = INT_MAX;
-    udp4_sec->receive_handler();
-    CHECK(observer->dataAvailable);
-    CHECK(observer->error);
-
-    udp4_sec->_is_handshaking = false;
     udp4_sec->_listening = false;
     observer->error = 0;
     observer->dataAvailable = false;
@@ -594,6 +572,16 @@ void Test_M2MConnectionHandlerPimpl_classic::test_receive_handshake_handler()
     udp4_sec->receive_handshake_handler();
     CHECK(!observer->error);
     CHECK(observer->addressReady);
+
+    udp4_sec->_is_handshaking = true;
+    udp4_sec->_handshake_retry = 100;
+    observer->error = 0;
+    observer->addressReady = 0;
+    m2mconnectionsecurityimpl_stub::use_inc_int = false;
+    m2mconnectionsecurityimpl_stub::int_value = M2MConnectionHandler::CONNECTION_ERROR_WANTS_READ;
+    udp4_sec->receive_handshake_handler();
+    CHECK(observer->error);
+    CHECK(!observer->addressReady);
 
     udp4_sec->_is_handshaking = true;
     observer->error = 0;

--- a/test/mbed-client-classic/unittest/stub/eventOS_stub.cpp
+++ b/test/mbed-client-classic/unittest/stub/eventOS_stub.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * Copyright (c) 2016 - 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ int8_t eventOS_event_handler_create(void (*handler_func_ptr)(arm_event_s *), uin
     return eventOS_stub::int8_value;
 }
 
-int8_t eventOS_event_send(arm_event_s *event)
+extern "C" int8_t eventOS_event_send(const arm_event_s *event)
 {
     if(event->data_ptr && !eventOS_stub::int8_value)
     {

--- a/test/mbed-client-classic/unittest/stub/m2mbase_stub.cpp
+++ b/test/mbed-client-classic/unittest/stub/m2mbase_stub.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2016 - 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.

--- a/test/mbed-client-classic/unittest/stub/m2mbase_stub.h
+++ b/test/mbed-client-classic/unittest/stub/m2mbase_stub.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2016 - 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.

--- a/test/mbed-client-classic/unittest/stub/m2mconnectionsecurity_stub.cpp
+++ b/test/mbed-client-classic/unittest/stub/m2mconnectionsecurity_stub.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * Copyright (c) 2016 - 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.
@@ -94,3 +94,6 @@ int M2MConnectionSecurity::read(unsigned char* buffer, uint16_t len){
     }
     return m2mconnectionsecurityimpl_stub::int_value;
 }
+
+void M2MConnectionSecurity::set_socket(void *socket, void *address){}
+

--- a/test/mbed-client-classic/unittest/stub/m2mobject_stub.cpp
+++ b/test/mbed-client-classic/unittest/stub/m2mobject_stub.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2016 - 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.

--- a/test/mbed-client-classic/unittest/stub/m2mresource_stub.cpp
+++ b/test/mbed-client-classic/unittest/stub/m2mresource_stub.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2016 - 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "m2mresource_stub.h"
+
 
 uint32_t m2mresource_stub::int_value;
 uint8_t* m2mresource_stub::delayed_token;
@@ -186,5 +187,5 @@ M2MObjectInstance& M2MResource::get_parent_object_instance() const
 
 const char* M2MResource::object_name() const
 {
-
 }
+

--- a/test/mbed-client-classic/unittest/stub/m2mresource_stub.h
+++ b/test/mbed-client-classic/unittest/stub/m2mresource_stub.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2016 - 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.

--- a/test/mbed-client-classic/unittest/stub/m2mresourceinstance_stub.cpp
+++ b/test/mbed-client-classic/unittest/stub/m2mresourceinstance_stub.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2016 - 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.

--- a/test/mbed-client-classic/unittest/stub/m2msecurity_stub.cpp
+++ b/test/mbed-client-classic/unittest/stub/m2msecurity_stub.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2016 - 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.

--- a/test/mbed-client-classic/unittest/stub/m2msecurity_stub.h
+++ b/test/mbed-client-classic/unittest/stub/m2msecurity_stub.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2016 - 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #define M2M_SECURITY_STUB_H
 
 #include "m2msecurity.h"
+
 
 //some internal test related stuff
 namespace m2msecurity_stub

--- a/test/mbed-client-classic/unittest/stub/m2mstringbufferbase_stub.cpp
+++ b/test/mbed-client-classic/unittest/stub/m2mstringbufferbase_stub.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.

--- a/test/mbed-client-classic/unittest/stub/m2mstringbufferbase_stub.h
+++ b/test/mbed-client-classic/unittest/stub/m2mstringbufferbase_stub.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.
@@ -20,3 +20,4 @@
 #include "m2mstringbufferbase.h"
 
 #endif // M2MSTRINGBUFFERBASE_STUB_H
+

--- a/test/mbed-client-classic/unittest/stub/nsdlaccesshelper_stub.cpp
+++ b/test/mbed-client-classic/unittest/stub/nsdlaccesshelper_stub.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.

--- a/test/mbed-client-classic/unittest/stub/nsdlaccesshelper_stub.h
+++ b/test/mbed-client-classic/unittest/stub/nsdlaccesshelper_stub.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * Copyright (c) 2017 ARM Limited. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the License); you may
  * not use this file except in compliance with the License.
@@ -26,4 +26,6 @@ namespace nsdlaccesshelper_stub
     extern uint8_t int_value;
     void clear();
 }
+
 #endif // NSDLACCESSHELPER_STUB_H
+


### PR DESCRIPTION
The pal_connect() may now issue only one callback, which will cause
a deadlock as the logic relied on previous behavior of getting at
least one event after connect() to be able to use select() for detecting
if connect was completed. Change logic to bravely retry pal_connect()
after any event around connect sequence.

Note: this is not complete as it has a race condition on state variable
and it is tested only on Linux so far.